### PR TITLE
README.md - mention certificate generation before "gulp serve"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Second run the tests to see if everything still works.
 
     gulp test
 
+If you do not have certificate u=yet, generate it:
+
+  mkdir -p ../certificates
+  openssl genrsa 2048 > ../certificates/matchminer.key
+  chmod 400 ../certificates/matchminer.key
+  openssl req -new -x509 -nodes -sha256 -days 365 -key ../certificates/matchminer.key -out ../certificates/matchminer.crt -subj "/C=US/ST=CA/L=MyCity/O=MyCompany/OU=ACC/CN=myemail@someemailprovider.com"
+
 After all these steps you can start the hot reloading development server
 
     gulp serve


### PR DESCRIPTION
Absence of certificate matchminer.key and matchminer.crt files mentioned in "settings" in properties/config.json will kill "gull serve" command